### PR TITLE
Automation of LD_LIBRARY_PATH for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,21 @@
                 <version>1.8</version>
             </extension>
         </extensions>
+	<pluginManagement>
+	  <plugins>
+	    <plugin>
+	      <groupId>org.apache.maven.plugins</groupId>
+	      <artifactId>maven-surefire-plugin</artifactId>
+	      <version>2.9</version>
+	      <configuration>
+		<environmentVariables>
+		  <LD_LIBRARY_PATH>target/classes</LD_LIBRARY_PATH>
+		  <DYLD_LIBRARY_PATH>target/classes</DYLD_LIBRARY_PATH>
+		</environmentVariables>
+	      </configuration>
+	    </plugin>
+	  </plugins>
+	</pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Here is the POM change to avoid the need to set LD_LIBRARY_PATH to run the unit tests.

I may proceed to make it avoid the need for LD_LIBRARY_PATH altogether.
