### PR TITLE
set cpuLayout at top of testIssue21 unit test

### DIFF
--- a/src/test/java/com/higherfrequencytrading/affinity/AffinityLockTest.java
+++ b/src/test/java/com/higherfrequencytrading/affinity/AffinityLockTest.java
@@ -136,7 +136,9 @@ public class AffinityLockTest {
     }
 
     @Test
-    public void testIssue21() {
+    public void testIssue21() throws IOException {
+        AffinityLock.cpuLayout(VanillaCpuLayout.fromCpuInfo());
+
         AffinityLock al = AffinityLock.acquireLock();
         AffinityLock alForAnotherThread = al.acquireLock(AffinityStrategies.ANY);
         if (Runtime.getRuntime().availableProcessors() > 2) {


### PR DESCRIPTION
On my system (4-core AMD processor) the cpu layout specified for `dumpLocksCoreDuo()` was causing a test failure in the subsequent `testIssue21()` test.  Resetting the layout to the default fixes the issue.  Another way to fix the tests on my machine was to move `testIssue21()` and `testIssue19()` to the beginning of `AffinityLockTest`.

This may fix https://github.com/peter-lawrey/Java-Thread-Affinity/issues/39, hard to tell without more detail on that issue.
