### PR TITLE
Fix build on JDK 8

### DIFF
--- a/src/main/java/com/higherfrequencytrading/affinity/AffinityLock.java
+++ b/src/main/java/com/higherfrequencytrading/affinity/AffinityLock.java
@@ -74,7 +74,7 @@ public class AffinityLock {
 
     /**
      * Set the CPU layout for this machine.  CPUs which are not mentioned will be ignored.
-     * <p/>
+     *
      * Changing the layout will have no impact on thread which have already been assigned.
      * It only affects subsequent assignments.
      *
@@ -107,7 +107,7 @@ public class AffinityLock {
 
     /**
      * Translate a layout id into a logical cpu id.
-     * <p/>
+     *
      * This translation is perform so that regardless of how
      *
      * @param id
@@ -149,7 +149,7 @@ public class AffinityLock {
 
     /**
      * Assign any free core to this thread.
-     * <p/>
+     *
      * In reality, only one cpu is assigned, the rest of the threads for that core are reservable so they are not used.
      *
      * @return A handle for the current AffinityLock.
@@ -160,7 +160,7 @@ public class AffinityLock {
 
     /**
      * Assign a cpu which can be bound to the current thread or another thread.
-     * <p/>
+     *
      * This can be used for defining your thread layout centrally and passing the handle via dependency injection.
      *
      * @param bind if true, bind the current thread, if false, reserve a cpu which can be bound later.
@@ -172,7 +172,7 @@ public class AffinityLock {
 
     /**
      * Assign a core(and all its cpus) which can be bound to the current thread or another thread.
-     * <p/>
+     *
      * This can be used for defining your thread layout centrally and passing the handle via dependency injection.
      *
      * @param bind if true, bind the current thread, if false, reserve a cpu which can be bound later.
@@ -329,7 +329,7 @@ public class AffinityLock {
 
     /**
      * Give another affinity lock relative to this one based on a list of strategies.
-     * <p/>
+     *
      * The strategies are evaluated in order to (like a search path) to find the next appropriate thread.
      * If ANY is not the last strategy, a warning is logged and no cpu is assigned (leaving the OS to choose)
      *

--- a/src/main/java/com/higherfrequencytrading/affinity/AffinityThreadFactory.java
+++ b/src/main/java/com/higherfrequencytrading/affinity/AffinityThreadFactory.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ThreadFactory;
 
 /**
  * This is a ThreadFactory which assigns threads based the strategies provided.
- * <p/>
+ *
  * If no strategies are provided AffinityStrategies.ANY is used.
  *
  * @author peter.lawrey

--- a/src/main/java/com/higherfrequencytrading/affinity/impl/PosixJNAAffinity.java
+++ b/src/main/java/com/higherfrequencytrading/affinity/impl/PosixJNAAffinity.java
@@ -28,7 +28,7 @@ import java.util.logging.Logger;
  * Implementation of {@link IAffinity} based on JNA call of
  * sched_setaffinity(3)/sched_getaffinity(3) from 'c' library. Applicable for most
  * linux/unix platforms
- * <p/>
+ *
  * TODO Support assignment to core 64 and above
  *
  * @author peter.lawrey

--- a/src/main/java/com/higherfrequencytrading/affinity/impl/WindowsJNAAffinity.java
+++ b/src/main/java/com/higherfrequencytrading/affinity/impl/WindowsJNAAffinity.java
@@ -31,7 +31,6 @@ import java.util.logging.Logger;
  * Implementation of {@link com.higherfrequencytrading.affinity.IAffinity} based on JNA call of
  * sched_SetThreadAffinityMask/GetProcessAffinityMask from Windows 'kernel32' library. Applicable for
  * most windows platforms
- * <p/> *
  *
  * @author andre.monteiro
  */

--- a/src/main/java/com/higherfrequencytrading/clock/IClock.java
+++ b/src/main/java/com/higherfrequencytrading/clock/IClock.java
@@ -26,10 +26,10 @@ public interface IClock {
 
     /**
      * The general contract is same, as {@link System#nanoTime()}:
-     * <p/>
+     *
      * Returns the current value of the most precise available system
      * timer, in nanoseconds.
-     * <p/>
+     *
      * <p>This method can only be used to measure elapsed time and is
      * not related to any other notion of system or wall-clock time.
      * The value returned represents nanoseconds since some fixed but
@@ -39,8 +39,8 @@ public interface IClock {
      * how frequently values change. Differences in successive calls
      * that span greater than approximately 292 years (2<sup>63</sup>
      * nanoseconds) will not accurately compute elapsed time due to
-     * numerical overflow.
-     * <p/>
+     * numerical overflow.</p>
+     *
      * <p> For example, to measure how long some code takes to execute:
      * <pre>
      *   long startTime = clock.nanoTime();


### PR DESCRIPTION
On JDK 8 the build fails with various Javadoc errors (tested with Oracle JDK 1.8.0_102). With this commit we fix these.